### PR TITLE
Rename AI_MODEL setting to OPENAI_API_MODEL for fleet consistency

### DIFF
--- a/config/settings.py
+++ b/config/settings.py
@@ -242,7 +242,7 @@ TAILWIND_CLI_DIST_CSS = env.str("TAILWIND_CLI_DIST_CSS", default="css/tailwind.c
 TAILWIND_CLI_SRC_CSS = env.str("TAILWIND_CLI_SRC_CSS", default="frontend/index.css")
 TAILWIND_CLI_VERSION = env.str("TAILWIND_CLI_VERSION", default="4.2.1")
 
-AI_MODEL = env("AI_MODEL", default="openai-chat:gpt-5-mini")
+OPENAI_API_MODEL = env("OPENAI_API_MODEL", default="openai-chat:gpt-5.4-nano")
 
 PRODUCTION_PROCESSES = {
     "web": {

--- a/races/agents.py
+++ b/races/agents.py
@@ -26,7 +26,7 @@ and 'discounts', use plain text (not HTML or markdown).
 
 def get_race_agent() -> Agent[None, RaceAgentResult]:
     return Agent(
-        settings.AI_MODEL,
+        settings.OPENAI_API_MODEL,
         system_prompt=SYSTEM_PROMPT,
         output_type=RaceAgentResult,
     )
@@ -155,7 +155,7 @@ def format_race_context(race) -> str:
 def get_chat_agent(race) -> Agent:
     race_context = format_race_context(race)
     return Agent(
-        settings.AI_MODEL,
+        settings.OPENAI_API_MODEL,
         system_prompt=CHAT_SYSTEM_PROMPT.format(race_context=race_context),
     )
 


### PR DESCRIPTION
trailhawks was the only app using `AI_MODEL` instead of `OPENAI_API_MODEL`. Renames the setting + both `races/agents.py` usages so it matches the other apps (full `openai-chat:` identifier in `OPENAI_API_MODEL`, passed directly to `Agent()`).

**No Coolify change needed** — trailhawks already has `OPENAI_API_MODEL=openai-chat:gpt-5.4-nano` set (it was dead because the code read `AI_MODEL`). This rename makes that env live.

**Behavior note:** the effective model changes from `gpt-5-mini` → `gpt-5.4-nano` (the fleet-wide value, now sourced from the live env).