### PR TITLE
Upgrade django-prodserver to 3.0.0

### DIFF
--- a/uv.lock
+++ b/uv.lock
@@ -614,14 +614,14 @@ wheels = [
 
 [[package]]
 name = "django-prodserver"
-version = "2.4.0"
+version = "3.0.0"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "django" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/28/a6/e16660d350bae21cc28aa7ae2a66f0a963c108834801d75591fe5f076ac1/django_prodserver-2.4.0.tar.gz", hash = "sha256:642a9d52829c56980e4f17f3c807e87be8f5584d3cddeae612c44c854866da79", size = 24088, upload-time = "2025-12-04T21:16:05.833Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/e9/67/732369cba62af180f224f20bf7ec02e95ad596b4e32d88eb6a8d2c67f312/django_prodserver-3.0.0.tar.gz", hash = "sha256:5e23ccd7338c26f2da203172b8ad2905ed4f2ae6b8f63b0e26c415dc5f9b2cfa", size = 36158, upload-time = "2026-05-13T09:01:30.332Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/13/f6/74efddbab4208f413eb5f1e0faff225911d1a7793bf0c523d2862b014307/django_prodserver-2.4.0-py3-none-any.whl", hash = "sha256:912096f383c9547227c8bc3db586f1acb68efaa4704b10a66d91016be1d67ee7", size = 15291, upload-time = "2025-12-04T21:16:04.81Z" },
+    { url = "https://files.pythonhosted.org/packages/57/c2/141a7c3a067571f1c759925e8fb630f5fe3ad63814b5de5f703fcdaa7fdd/django_prodserver-3.0.0-py3-none-any.whl", hash = "sha256:00a8173b58c639d24733c397ff49153c6bde32f375834254f82b20651be21ed8", size = 33227, upload-time = "2026-05-13T09:01:28.624Z" },
 ]
 
 [package.optional-dependencies]


### PR DESCRIPTION
Standardizes on the latest django-prodserver (3.0.0). Backwards-compatible: the `prodserver` command and `backends.gunicorn.GunicornServer` import path still work (now deprecated aliases). Lock-only change.