### PR TITLE
Add django.contrib.postgres for ArrayField (Django 6.0)

### DIFF
--- a/config/settings.py
+++ b/config/settings.py
@@ -82,6 +82,7 @@ INSTALLED_APPS = [
     "django.contrib.flatpages",
     "django.contrib.humanize",
     "django.contrib.messages",
+    "django.contrib.postgres",
     "django.contrib.redirects",
     "django.contrib.sessions",
     "django.contrib.sitemaps",


### PR DESCRIPTION
Django 6.0 enforces `postgres.E005`: models using ArrayField require `django.contrib.postgres` in INSTALLED_APPS. Without this the app raises a system check error at startup and any code path touching those fields 500s. Verified locally: `manage check` no longer reports E005.